### PR TITLE
profile: decrease thresholds of minimal reads and unique reads in preset profiling modes 1 and 2 for low coverage sequence data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v0.8.2 - 2022-03-07
+### v0.8.2 - 2022-03-26
 
 - `search`: 
     - flag `-g/--query-whole-file`:
@@ -8,7 +8,9 @@
         - add gaps of `k-1` bp before concatatenating seqs.
     - add warning for invalid input.
 - `profile`:
-    - *allow changing parts of the parameters for preset profiling modes*. [#5](https://github.com/shenwei356/kmcp/issues/5)
+    - ***allow changing parts of the parameters for preset profiling modes***. [#5](https://github.com/shenwei356/kmcp/issues/5)
+    - decrease thresholds of minimal reads and unique reads in preset profiling modes 1 and 2 for low coverage sequence data.
+      the profiling results in the manuscript are not affected which are generated with the mode 3.
 
 ### v0.8.1 - 2022-03-07
 

--- a/docs/tutorial/profiling/index.md
+++ b/docs/tutorial/profiling/index.md
@@ -384,15 +384,15 @@ You can still change the values of some options below as usual.
 
     options                       m=0    m=1   m=2   m=3    m=4   m=5
     ---------------------------   ----   ---   ---   ----   ---   ----
-    -r/--min-chunks-reads         1      20    30    50     100   100
-    -p/--min-chunks-fraction      0.2    0.5   0.7   0.8    1     1
-    -d/--max-chunks-depth-stdev   10     10    3     2      2     1.5
-    -u/--min-uniq-reads           1      20    20    20     50    50
-    -U/--min-hic-ureads           1      5     5     5      10    10
+    -r/--min-chunks-reads         1      5     10    50     100   100
+    -p/--min-chunks-fraction      0.2    0.6   0.7   0.8    1     1
+    -d/--max-chunks-depth-stdev   10     2     2     2      2     1.5
+    -u/--min-uniq-reads           1      2     5     20     50    50
+    -U/--min-hic-ureads           1      1     2     5      10    10
     -H/--min-hic-ureads-qcov      0.55   0.7   0.7   0.75   0.8   0.8
     -P/--min-hic-ureads-prop      0.01   0.1   0.2   0.1    0.1   0.15
     --keep-main-matches           true                            
-    --max-qcov-gap                0.4
+    --max-qcov-gap                0.4                       
     
 **Taxonomy data**:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,7 +5,7 @@ KMCP is a command-line tool consisting of several subcommands.
 ```text
 
     Program: kmcp (K-mer-based Metagenomic Classification and Profiling)
-    Version: v0.8.1
+    Version: v0.8.2
   Documents: https://bioinf.shenwei.me/kmcp
 Source code: https://github.com/shenwei356/kmcp
 
@@ -467,15 +467,15 @@ Profiling modes:
 
     options                       m=0    m=1   m=2   m=3    m=4   m=5
     ---------------------------   ----   ---   ---   ----   ---   ----
-    -r/--min-chunks-reads         1      20    30    50     100   100
-    -p/--min-chunks-fraction      0.2    0.5   0.7   0.8    1     1
-    -d/--max-chunks-depth-stdev   10     10    3     2      2     1.5
-    -u/--min-uniq-reads           1      20    20    20     50    50
-    -U/--min-hic-ureads           1      5     5     5      10    10
+    -r/--min-chunks-reads         1      5     10    50     100   100
+    -p/--min-chunks-fraction      0.2    0.6   0.7   0.8    1     1
+    -d/--max-chunks-depth-stdev   10     2     2     2      2     1.5
+    -u/--min-uniq-reads           1      2     5     20     50    50
+    -U/--min-hic-ureads           1      1     2     5      10    10
     -H/--min-hic-ureads-qcov      0.55   0.7   0.7   0.75   0.8   0.8
     -P/--min-hic-ureads-prop      0.01   0.1   0.2   0.1    0.1   0.15
     --keep-main-matches           true                            
-    --max-qcov-gap                0.4                             
+    --max-qcov-gap                0.4                       
 
 Taxonomy data:
   1. Mapping references IDs to TaxIds: -T/--taxid-map

--- a/kmcp/cmd/profile.go
+++ b/kmcp/cmd/profile.go
@@ -247,11 +247,11 @@ Examples:
 		}
 
 		presetParams[1] = profileParams{
-			minReads:           20,
-			minFragsProp:       0.5,
-			maxFragsDepthStdev: 10,
-			minUReads:          20,
-			minHicUreads:       5,
+			minReads:           5,
+			minFragsProp:       0.6,
+			maxFragsDepthStdev: 2,
+			minUReads:          2,
+			minHicUreads:       1,
 			hicUreadsMinQcov:   0.7,
 			HicUreadsMinProp:   0.1,
 			keepMainMatch:      false,
@@ -259,11 +259,11 @@ Examples:
 		}
 
 		presetParams[2] = profileParams{
-			minReads:           30,
+			minReads:           10,
 			minFragsProp:       0.7,
-			maxFragsDepthStdev: 3,
-			minUReads:          20,
-			minHicUreads:       5,
+			maxFragsDepthStdev: 2,
+			minUReads:          5,
+			minHicUreads:       2,
 			hicUreadsMinQcov:   0.7,
 			HicUreadsMinProp:   0.2,
 			keepMainMatch:      false,

--- a/kmcp/profiling-mode.tsv
+++ b/kmcp/profiling-mode.tsv
@@ -1,9 +1,9 @@
 options	m=0	m=1	m=2	m=3	m=4	m=5
--r/--min-chunks-reads	1	20	30	50	100	100
--p/--min-chunks-fraction	0.2	0.5	0.7	0.8	1	1
--d/--max-chunks-depth-stdev	10	10	3	2	2	1.5
--u/--min-uniq-reads	1	20	20	20	50	50
--U/--min-hic-ureads	1	5	5	5	10	10
+-r/--min-chunks-reads	1	5	10	50	100	100
+-p/--min-chunks-fraction	0.2	0.6	0.7	0.8	1	1
+-d/--max-chunks-depth-stdev	10	2	2	2	2	1.5
+-u/--min-uniq-reads	1	2	5	20	50	50
+-U/--min-hic-ureads	1	1	2	5	10	10
 -H/--min-hic-ureads-qcov	0.55	0.7	0.7	0.75	0.8	0.8
 -P/--min-hic-ureads-prop	0.01	0.1	0.2	0.1	0.1	0.15
 --keep-main-matches	true					


### PR DESCRIPTION
decrease thresholds of minimal reads and unique reads in preset profiling modes 1 and 2 for low coverage sequence data.

the profiling results in the manuscript are not affected which are generated with mode 3